### PR TITLE
Remove unnecessary STDERR output

### DIFF
--- a/src/org/swtjar/SWTLoader.java
+++ b/src/org/swtjar/SWTLoader.java
@@ -42,7 +42,7 @@ public class SWTLoader
       {
         try
         {
-          System.err.println("Launching UI ...");
+          //System.err.println("Launching UI ...");
           Class<?> c = Class.forName(sTargetMainClass, true, cl);
           Method main = c.getMethod("main", new Class[]{args.getClass()});
           main.invoke((Object)null, new Object[]{args});
@@ -193,7 +193,7 @@ public class SWTLoader
       addUrlMethod.setAccessible(true);
 
       URL swtFileUrl = new URL("rsrc:" + swtFileName);
-      System.err.println("Using SWT Jar: " + swtFileName);
+      //System.err.println("Using SWT Jar: " + swtFileName);
       addUrlMethod.invoke(cl, swtFileUrl);
 
       return cl;


### PR DESCRIPTION
My SWT app has both a UI and CLI mode.  The STDERR output from swtjar
has been a huge source of confusion for my users.  I've had several
issue tickets asking if this STDERR output indicates something is
wrong.

Leaving the output as commented out in case it might be helpful when
debugging issues.
